### PR TITLE
Remove explicit dependency on `@bigtest/convergence`

### DIFF
--- a/ember/todomvc/package.json
+++ b/ember/todomvc/package.json
@@ -18,7 +18,6 @@
     "exam": "ember exam"
   },
   "devDependencies": {
-    "@bigtest/convergence": "^1.0.0",
     "@bigtest/interactor": "^0.7.2",
     "@ember-decorators/babel-transforms": "^2.0.0",
     "babel-eslint": "^8.0.0",

--- a/ember/todomvc/tests/acceptance/todomvc-test.js
+++ b/ember/todomvc/tests/acceptance/todomvc-test.js
@@ -5,7 +5,6 @@ import startApp from "todomvc/tests/helpers/start-app";
 import destroyApp from "todomvc/tests/helpers/destroy-app";
 import { percySnapshot } from "ember-percy";
 import TodoMVC from "todomvc/tests/interactors/app";
-import { when } from "@bigtest/convergence";
 
 describe("Acceptance | todomvc", function() {
   let application;
@@ -26,69 +25,74 @@ describe("Acceptance | todomvc", function() {
 
   describe("When page is initially opened", () => {
     it("should focus on the todo input field", async () => {
-      await when(() => expect(TodoApp.newInputIsFocused).to.equal(true));
+      await TodoApp.when(() => expect(TodoApp.newInputIsFocused).to.equal(true));
     });
   });
 
   describe("No Todos", () => {
     it("should hide #main and #footer", async function() {
-      await when(() => {
+      await TodoApp.when(() => {
         expect(TodoApp.todoList().length).to.equal(0);
         expect(TodoApp.footerExists).to.equal(false);
-      });
-
-      await percySnapshot(this.test);
+      }).do(() => percySnapshot(this.test));
     });
   });
 
   describe("New Todo", function() {
     it("should allow me to add todo items", async function() {
       // create 1st todo
-      await TodoApp.newTodo("My First Todo").submitTodo();
-
-      // make sure the 1st label contains the 1st todo text
-      await when(() => expect(TodoApp.todoList(0).todoText).to.equal("My First Todo"));
-
-      // create 2nd todo
-      await TodoApp.newTodo("My Second Todo").submitTodo();
-
-      // make sure the 2nd label contains the 2nd todo text
-      await when(() => expect(TodoApp.todoList(1).todoText).to.equal("My Second Todo"));
-      await percySnapshot(this.test);
+      await TodoApp
+        .newTodo("My First Todo")
+        .submitTodo()
+        // make sure the 1st label contains the 1st todo text
+        .when(() => expect(TodoApp.todoList(0).todoText).to.equal("My First Todo"))
+        // create 2nd todo
+        .newTodo("My Second Todo")
+        .submitTodo()
+        // make sure the 2nd label contains the 2nd todo text
+        .when(() => expect(TodoApp.todoList(1).todoText).to.equal("My Second Todo"))
+        .do(() => percySnapshot(this.test));
     });
 
     it("should clear text input field when an item is added", async () => {
-      await TodoApp.newTodo("My First Todo").submitTodo();
-      await when(() => expect(TodoApp.newTodoInputValue).to.equal(""));
+      await TodoApp
+        .newTodo("My First Todo")
+        .submitTodo()
+        .when(() => expect(TodoApp.newTodoInputValue).to.equal(""));
     });
 
     it("should append new items to the bottom of the list", async function() {
-      await TodoApp.newTodo("My First Todo").submitTodo();
-      await when(() => expect(TodoApp.todoList(0).todoText).to.equal("My First Todo"));
-
-      await TodoApp.newTodo("My Second Todo").submitTodo();
-      await when(() => expect(TodoApp.todoList(1).todoText).to.equal("My Second Todo"));
-
-      await TodoApp.newTodo("My Third Todo").submitTodo();
-      await when(() => expect(TodoApp.todoList(2).todoText).to.equal("My Third Todo"));
-      await when(() => expect(TodoApp.todoCountText).to.equal("3 items left"));
-      await percySnapshot(this.test);
+      await TodoApp
+        .newTodo("My First Todo")
+        .submitTodo()
+        .when(() => expect(TodoApp.todoList(0).todoText).to.equal("My First Todo"))
+        .newTodo("My Second Todo")
+        .submitTodo()
+        .when(() => expect(TodoApp.todoList(1).todoText).to.equal("My Second Todo"))
+        .newTodo("My Third Todo")
+        .submitTodo()
+        .when(() => expect(TodoApp.todoList(2).todoText).to.equal("My Third Todo"))
+        .when(() => expect(TodoApp.todoCountText).to.equal("3 items left"))
+        .do(() => percySnapshot(this.test));
     });
 
     it("should trim text input", async function() {
-      await TodoApp.newTodo("    My First Todo     ").submitTodo();
-      await when(() => expect(TodoApp.todoList(0).todoText).to.equal("My First Todo"));
+      await TodoApp
+        .newTodo("    My First Todo     ")
+        .submitTodo()
+        .when(() => expect(TodoApp.todoList(0).todoText).to.equal("My First Todo"));
     });
 
     it("should show #main and #footer when items added", async function() {
-      await TodoApp.newTodo("My First Todo").submitTodo();
-
-      await when(() => {
-        expect(TodoApp.footerExists).to.equal(true);
-        expect(TodoApp.todoList().length).to.equal(1);
-        expect(TodoApp.todoCountText).to.equal("1 item left");
-      });
-      await percySnapshot(this.test);
+      await TodoApp
+        .newTodo("My First Todo")
+        .submitTodo()
+        .when(() => {
+          expect(TodoApp.footerExists).to.equal(true);
+          expect(TodoApp.todoList().length).to.equal(1);
+          expect(TodoApp.todoCountText).to.equal("1 item left");
+        })
+        .do(() => percySnapshot(this.test));
     });
   });
 
@@ -98,83 +102,90 @@ describe("Acceptance | todomvc", function() {
     });
 
     it("should allow me to mark all items as completed", async function() {
-      await TodoApp.completeAllTodos();
-
-      // get each todo li and ensure it is 'completed'
-      await when(() => {
-        expect(TodoApp.todoList(0).isCompleted).to.equal(true);
-        expect(TodoApp.todoList(1).isCompleted).to.equal(true);
-      });
-      await percySnapshot(this.test);
+      await TodoApp
+        .completeAllTodos()
+        // get each todo li and ensure it is 'completed'
+        .when(() => {
+          expect(TodoApp.todoList(0).isCompleted).to.equal(true);
+          expect(TodoApp.todoList(1).isCompleted).to.equal(true);
+        })
+        .do(() => percySnapshot(this.test));
     });
 
     it("should allow me to clear the complete state of all items", async function() {
       // check and then immediately uncheck
-      await TodoApp.completeAllTodos().completeAllTodos();
-
-      await when(() => expect(TodoApp.todoList(0).isCompleted).to.equal(false));
-      await when(() => expect(TodoApp.todoList(1).isCompleted).to.equal(false));
-      await percySnapshot(this.test);
+      await TodoApp
+        .completeAllTodos()
+        .completeAllTodos()
+        .when(() => {
+          expect(TodoApp.todoList(0).isCompleted).to.equal(false);
+          expect(TodoApp.todoList(1).isCompleted).to.equal(false);
+        })
+        .do(() => percySnapshot(this.test));
     });
 
     it("complete all checkbox should update state when items are completed / cleared", async function() {
-      await TodoApp.completeAllTodos();
-      await when(() => expect(TodoApp.completeAllIsChecked).to.equal(true));
-      await TodoApp.todoList(0).toggle();
-
-      // make sure toggle all is not checked
-      await when(() => expect(TodoApp.completeAllIsChecked).to.equal(false));
-
-      // toggle the first todo
-      await TodoApp.todoList(0).toggle();
-
-      // assert the toggle all is checked again
-      await when(() => expect(TodoApp.completeAllIsChecked).to.equal(true));
-      await percySnapshot(this.test);
+      await TodoApp
+        .completeAllTodos()
+        .when(() => expect(TodoApp.completeAllIsChecked).to.equal(true))
+        .todoList(0).toggle()
+        // make sure toggle all is not checked
+        .when(() => expect(TodoApp.completeAllIsChecked).to.equal(false))
+        // toggle the first todo
+        .todoList(0).toggle()
+        // assert the toggle all is checked again
+        .when(() => expect(TodoApp.completeAllIsChecked).to.equal(true))
+        .do(() => percySnapshot(this.test));
     });
   });
 
   describe("Item", function() {
     it("should allow me to mark items as complete", async function() {
-      await TodoApp.createTwoTodos();
-
-      await TodoApp.todoList(0).toggle();
-      await when(() => expect(TodoApp.todoList(0).isCompleted).to.equal(true));
-
-      await when(() => expect(TodoApp.todoList(1).isCompleted).to.equal(false));
-      await TodoApp.todoList(1).toggle();
-
-      await when(() => expect(TodoApp.todoList(0).isCompleted).to.equal(true));
-      await when(() => expect(TodoApp.todoList(1).isCompleted).to.equal(true));
-      await percySnapshot(this.test);
+      await TodoApp
+        .createTwoTodos()
+        .todoList(0).toggle()
+        .when(() => expect(TodoApp.todoList(0).isCompleted).to.equal(true))
+        .when(() => expect(TodoApp.todoList(1).isCompleted).to.equal(false))
+        .todoList(1).toggle()
+        .when(() => {
+          expect(TodoApp.todoList(0).isCompleted).to.equal(true);
+          expect(TodoApp.todoList(1).isCompleted).to.equal(true);
+        })
+        .do(percySnapshot(this.test));
     });
 
     it("should allow me to un-mark items as complete", async function() {
-      await TodoApp.createTwoTodos();
-
-      await TodoApp.todoList(0).toggle();
-      await when(() => expect(TodoApp.todoList(0).isCompleted).to.equal(true));
-      await when(() => expect(TodoApp.todoList(1).isCompleted).to.equal(false));
-
-      await TodoApp.todoList(0).toggle();
-      await when(() => expect(TodoApp.todoList(0).isCompleted).to.equal(false));
-      await when(() => expect(TodoApp.todoList(1).isCompleted).to.equal(false));
-      await percySnapshot(this.test);
+      await TodoApp
+        .createTwoTodos()
+        .todoList(0).toggle()
+        .when(() => {
+          expect(TodoApp.todoList(0).isCompleted).to.equal(true);
+          expect(TodoApp.todoList(1).isCompleted).to.equal(false);
+        })
+        .todoList(0).toggle()
+        .when(() => {
+          expect(TodoApp.todoList(0).isCompleted).to.equal(false);
+          expect(TodoApp.todoList(1).isCompleted).to.equal(false);
+        })
+        .do(() => percySnapshot(this.test));
     });
 
     it("should allow me to edit an item", async function() {
-      await TodoApp.createTwoTodos();
-
-      await TodoApp.todoList(1)
+      await TodoApp
+        .createTwoTodos()
+        .todoList(1)
         .only()
         .doubleClick()
         .fillInput("buy some sausages")
         .pressEnter();
 
       // explicitly assert about the text value
-      await when(() => expect(TodoApp.todoList(0).text).to.equal("My First Todo"));
-      await when(() => expect(TodoApp.todoList(1).text).to.equal("buy some sausages"));
-      await percySnapshot(this.test);
+      await TodoApp
+        .when(() => {
+          expect(TodoApp.todoList(0).text).to.equal("My First Todo")
+          expect(TodoApp.todoList(1).text).to.equal("buy some sausages")
+        })
+        .do(() => percySnapshot(this.test));
     });
   });
 
@@ -184,13 +195,13 @@ describe("Acceptance | todomvc", function() {
     });
 
     it("should hide other controls when editing", async function() {
-      await TodoApp.todoList(1).doubleClick();
-
-      await when(() => {
-        expect(TodoApp.todoList(1).labelIsVisible).to.equal(false);
-        expect(TodoApp.todoList(1).toggleIsVisible).to.equal(false);
-      });
-      await percySnapshot(this.test);
+      await TodoApp
+        .todoList(1).doubleClick()
+        .when(() => {
+          expect(TodoApp.todoList(1).labelIsVisible).to.equal(false);
+          expect(TodoApp.todoList(1).toggleIsVisible).to.equal(false);
+        })
+        .do(() => percySnapshot(this.test));
     });
 
     it("should save edits on blur", async function() {
@@ -198,10 +209,11 @@ describe("Acceptance | todomvc", function() {
         .only()
         .doubleClick()
         .fillInput("buy some sausages")
-        .blurInput();
-
-      await when(() => expect(TodoApp.todoList(0).text).to.equal("My First Todo"));
-      await when(() => expect(TodoApp.todoList(1).text).to.equal("buy some sausages"));
+        .blurInput()
+        .when(() => {
+          expect(TodoApp.todoList(0).text).to.equal("My First Todo");
+          expect(TodoApp.todoList(1).text).to.equal("buy some sausages");
+        });
     });
 
     it("should trim entered text", async function() {
@@ -209,11 +221,12 @@ describe("Acceptance | todomvc", function() {
         .only()
         .doubleClick()
         .fillInput("    buy some sausages    ")
-        .pressEnter();
-
-      await when(() => expect(TodoApp.todoList(0).text).to.equal("My First Todo"));
-      await when(() => expect(TodoApp.todoList(1).text).to.equal("buy some sausages"));
-      await percySnapshot(this.test);
+        .pressEnter()
+        .when(() => {
+          expect(TodoApp.todoList(0).text).to.equal("My First Todo");
+          expect(TodoApp.todoList(1).text).to.equal("buy some sausages");
+        })
+        .do(() => percySnapshot(this.test));
     });
 
     it("should remove the item if an empty text string was entered", async function() {
@@ -221,9 +234,8 @@ describe("Acceptance | todomvc", function() {
         .only()
         .doubleClick()
         .fillInput("")
-        .pressEnter();
-
-      await when(() => expect(TodoApp.todoList().length).to.equal(1));
+        .pressEnter()
+        .when(() => expect(TodoApp.todoList().length).to.equal(1));
     });
 
     it("should cancel edits on escape", async function() {
@@ -231,22 +243,26 @@ describe("Acceptance | todomvc", function() {
         .only()
         .doubleClick()
         .fillInput("")
-        .pressEscape();
-
-      await when(() => expect(TodoApp.todoList(0).text).to.equal("My First Todo"));
-      await when(() => expect(TodoApp.todoList(1).text).to.equal("My Second Todo"));
-      await percySnapshot(this.test);
+        .pressEscape()
+        .when(() => {
+          expect(TodoApp.todoList(0).text).to.equal("My First Todo")
+          expect(TodoApp.todoList(1).text).to.equal("My Second Todo")
+        })
+        .do(() => percySnapshot(this.test));
     });
   });
 
   describe("Counter", function() {
     it("should display the current number of todo items", async function() {
-      await TodoApp.newTodo("My First Todo").submitTodo();
-      await when(() => expect(TodoApp.todoCountText).to.equal("1 item left"));
+      await TodoApp
+        .newTodo("My First Todo")
+        .submitTodo()
+        .when(() => expect(TodoApp.todoCountText).to.equal("1 item left"))
+        .newTodo("My Second Todo")
+        .submitTodo()
+        .when(() => expect(TodoApp.todoCountText).to.equal("2 items left"))
+        .do(() => percySnapshot(this.test));
 
-      await TodoApp.newTodo("My Second Todo").submitTodo();
-      await when(() => expect(TodoApp.todoCountText).to.equal("2 items left"));
-      await percySnapshot(this.test);
     });
   });
 
@@ -256,26 +272,29 @@ describe("Acceptance | todomvc", function() {
     });
 
     it("should display the correct text", async function() {
-      await TodoApp.todoList(0).toggle();
-      await when(() => expect(TodoApp.clearCompletedText).to.equal("Clear completed"));
+      await TodoApp
+        .todoList(0).toggle()
+        .when(() => expect(TodoApp.clearCompletedText).to.equal("Clear completed"));
     });
 
     it("should remove completed items when clicked", async function() {
-      await TodoApp.todoList(0)
-        .toggle()
-        .clearCompleted();
-
-      await when(() => expect(TodoApp.todoList().length).to.equal(1));
-      await when(() => expect(TodoApp.todoList(0).text).to.equal("My Second Todo"));
-      await percySnapshot(this.test);
+      await TodoApp
+        .todoList(0).toggle()
+        .clearCompleted()
+        .when(() => {
+          expect(TodoApp.todoList().length).to.equal(1);
+          expect(TodoApp.todoList(0).text).to.equal("My Second Todo");
+        })
+        .do(() => percySnapshot(this.test));
     });
 
     it("should be hidden when there are no items that are completed", async function() {
-      await TodoApp.todoList(0).toggle();
-      await when(() => expect(TodoApp.clearCompletedText).to.equal("Clear completed"));
-      await TodoApp.clearCompleted();
-      await when(() => expect(TodoApp.clearCompletedPresent).to.equal(false));
-      await percySnapshot(this.test);
+      await TodoApp
+        .todoList(0).toggle()
+        .when(() => expect(TodoApp.clearCompletedText).to.equal("Clear completed"))
+        .clearCompleted()
+        .when(() => expect(TodoApp.clearCompletedPresent).to.equal(false))
+        .do(() => percySnapshot(this.test));
     });
   });
 
@@ -285,38 +304,37 @@ describe("Acceptance | todomvc", function() {
     });
 
     it("should allow me to display active items", async function() {
-      await TodoApp.todoList(1)
-        .toggle()
-        .clickActiveFilter();
-      await when(() => expect(TodoApp.todoList(0).text).to.equal("My First Todo"));
-      await when(() => expect(TodoApp.todoList().length).to.equal(1));
+      await TodoApp
+        .todoList(1).toggle()
+        .clickActiveFilter()
+        .when(() => {
+          expect(TodoApp.todoList(0).text).to.equal("My First Todo")
+          expect(TodoApp.todoList().length).to.equal(1)
+        });
     });
 
     it("should allow me to display completed items", async function() {
-      await TodoApp.todoList(1)
-        .toggle()
-        .clickCompleteFilter();
-
-      await when(() => expect(TodoApp.todoList(0).text).to.equal("My Second Todo"));
-      await when(() => expect(TodoApp.todoList().length).to.equal(1));
+      await TodoApp
+        .todoList(1).toggle()
+        .clickCompleteFilter()
+        .when(() => {
+          expect(TodoApp.todoList(0).text).to.equal("My Second Todo");
+          expect(TodoApp.todoList().length).to.equal(1);
+        });
     });
 
     it("should allow me to display all items", async function() {
-      await TodoApp.todoList(1)
-        .toggle()
+      await TodoApp
+        .todoList(1).toggle()
         .clickActiveFilter()
         .clickCompleteFilter()
-        .clickAllFilter();
-
-      await when(() => expect(TodoApp.todoList().length).to.equal(2));
-      await percySnapshot(this.test);
+        .clickAllFilter()
+        .when(() => expect(TodoApp.todoList().length).to.equal(2))
+        .do(() => percySnapshot(this.test));
     });
 
-    it(
-      "should highlight the currently applied filter",
-      when(() => {
-        expect(TodoApp.allFilterHasSelectedClass).to.equal(true);
-      })
-    );
+    it("should highlight the currently applied filter", async () => {
+      await TodoApp.when(() => expect(TodoApp.allFilterHasSelectedClass).to.equal(true));
+    });
   });
 });

--- a/ember/todomvc/tests/interactors/app.js
+++ b/ember/todomvc/tests/interactors/app.js
@@ -1,4 +1,3 @@
-import { when } from "@bigtest/convergence";
 import {
   is,
   text,
@@ -40,12 +39,14 @@ class TodoMVC {
     keyCode: 13
   });
 
-  async createTwoTodos() {
-    await this.newTodo("My First Todo").submitTodo();
-    await when(() => this.todoList(0).isPresent);
-
-    await this.newTodo("My Second Todo").submitTodo();
-    await when(() => this.todoList(1).isPresent);
+  createTwoTodos() {
+    return this
+      .newTodo("My First Todo")
+      .submitTodo()
+      .when(() => this.todoList(0).isPresent)
+      .newTodo("My Second Todo")
+      .submitTodo()
+      .when(() => this.todoList(1).isPresent);
   }
 }
 

--- a/ember/todomvc/yarn.lock
+++ b/ember/todomvc/yarn.lock
@@ -217,10 +217,6 @@
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/@bigtest/convergence/-/convergence-0.10.0.tgz#ed2212b7034c84917ccfbaa8cf875730ee535702"
 
-"@bigtest/convergence@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@bigtest/convergence/-/convergence-1.0.0.tgz#7bca36af5b6eae2e6fd47c07f28901397b338d7d"
-
 "@bigtest/interactor@^0.7.2":
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/@bigtest/interactor/-/interactor-0.7.2.tgz#64e82cbd935d2a7e62b58be7488d461e997a7b31"


### PR DESCRIPTION
## What is this?

Interactors depend on `@bigtest/convergence` and expose the `when` & `do` methods to us. So we can remove `@bigtest/convergence` from the test suite and use the interactor convergence methods to chain everything together in a much nicer syntax.

This is what you would do if you want to avoid writing `when` to make assertions. 